### PR TITLE
Update local docker setup so it builds and registers with the Control Tower correctly

### DIFF
--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -10,7 +10,7 @@ services:
       NODE_PATH: app/src
       CT_REGISTER_MODE: auto
       CT_URL: http://mymachine:9000
-      LOCAL_URL: http://192.168.1.50:4400
+      LOCAL_URL: http://mymachine:4400
       CT_TOKEN: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Im1pY3Jvc2VydmljZSIsImNyZWF0ZWRBdCI6IjIwMTYtMDktMTQifQ.IRCIRm1nfIQTfda_Wb6Pg-341zhV8soAgzw7dd5HxxQ
       API_VERSION: v1
       FASTLY_ENABLED: "false"


### PR DESCRIPTION
I have made a series of small changes which ensures that the microservices build and register with the Control Tower locally with Docker.

The changes to this repo are:
- Fix Local URL